### PR TITLE
[RSS-56] DELETE /shifts/:startTimestamp Endpoint

### DIFF
--- a/amplify/backend/function/risestandstrongcb34053a/src/routes/shifts.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/routes/shifts.js
@@ -1,8 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { postShift, queryShiftsRange } = require('../utils/aws-utils');
-const { getShift } = require('../utils/aws-utils');
-const { v4: uuidv4 } = require('uuid');
+const { postShift, queryShiftsRange, getShift, deleteShift, } = require('../utils/aws-utils');
 
 /**
  * @swagger
@@ -54,13 +52,13 @@ router.post('/', async (req, res) => {
    }
 
    try {
-       await postShift(newShift);
-       res.send(newShift);
+      await postShift(newShift);
+      res.send(newShift);
    }
    catch (err) {
       // TODO: Once we have the user pools and IAM set up throw a 403 if not
       // allowed to access writing to a table
-       res.status(400).json(err);
+      res.status(400).json(err);
    }
 })
 
@@ -139,14 +137,23 @@ router.get('/', async (req, res) => {
  *            description: startTimestamp not found
  */
 router.get('/:startTimestamp', async (req, res) => {
-   let startTimestamp = req.params.startTimestamp;
-   try {
-     const shift = await getShift(startTimestamp);
-     res.send(shift)
+   let { startTimestamp } = req.params;
+   const parsedTs = parseInt(startTimestamp);
+
+   if(isNaN(parsedTs)) {
+      res.status(400).send({
+         error: 'startTimestamp is required and must be a Number',
+      });
+   } else {
+      try {
+         const shift = await getShift(parsedTs);
+         res.send(shift);
+      } catch (err) {
+         res.status(404).json(err);
+      }
    }
-   catch (err) {
-      res.status(404).json({ error });
-   }
+
+
 })
 
 
@@ -225,7 +232,21 @@ router.put('/:startTimestamp', async (req, res) => {
  *            description: startTimestamp not found
  */
 router.delete('/:startTimestamp', async (req, res) => {
-   res.end();
+   const { startTimestamp } = req.params;
+   const parsedTs = parseInt(startTimestamp);
+
+   if(isNaN(parsedTs)) {
+      res.status(400).send({
+         error: 'startTimestamp is required and must be a Number',
+      });
+   } else {
+      try {
+         await deleteShift(parsedTs);
+         res.send();
+      } catch (err) {
+         res.status(400).send(err);
+      }
+   }
 })
 
 

--- a/amplify/backend/function/risestandstrongcb34053a/src/routes/shifts.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/routes/shifts.js
@@ -137,7 +137,7 @@ router.get('/', async (req, res) => {
  *            description: startTimestamp not found
  */
 router.get('/:startTimestamp', async (req, res) => {
-   let { startTimestamp } = req.params;
+   const { startTimestamp } = req.params;
    const parsedTs = parseInt(startTimestamp);
 
    if(isNaN(parsedTs)) {

--- a/amplify/backend/function/risestandstrongcb34053a/src/utils/aws-utils.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/utils/aws-utils.js
@@ -91,16 +91,28 @@ async function postShift(shiftBody) {
 async function getShift(startTimestamp) {
     const docClient = new AWS.DynamoDB.DocumentClient();
     const params = {
-        TableName: 'shifts',
+        TableName: 'shiftsV2',
         Key: {
-            startTimestamp: startTimestamp
+            pk: 'RSS',
+            startTimestamp,
         }
     };
     try {
-        let shift = await docClient.get(params).promise();
-        return shift
+        let shiftResp = await docClient.get(params).promise();
+        return shiftResp.Item;
     } catch (err) {
+        console.log(err);
+        throw err;
+    }
+}
 
+/**
+ * Funciton that returns all of the shift objects in DynamoDB that have
+ * startTimestamps inbetween startTimestamp and endTimestamp.
+ * 
+ * @param {Number} startTimestamp 
+ * @param {Number} endTimestamp 
+ */
 async function queryShiftsRange(startTimestamp, endTimestamp) {
     const docClient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10'});
     var params = {
@@ -125,10 +137,35 @@ async function queryShiftsRange(startTimestamp, endTimestamp) {
     }
 }
 
+/**
+ * Function that takes in a startTimestamp and deletes the corresponding 
+ * shift from DynamoDB. Throws an error if not found.
+ * 
+ * @param {Number} startTimestamp 
+ */
+async function deleteShift(startTimestamp) {
+    const docClient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10'});
+    const params = {
+        TableName: 'shiftsV2',
+        Key: {
+            pk: 'RSS',
+            startTimestamp,
+        }
+    };
+
+    try {
+        return await docClient.delete(params).promise();
+    } catch(err) {
+        console.log(err);
+        throw err;
+    }
+}
+
 module.exports = {
     postAnnouncement,
-    getAnnouncements
+    getAnnouncements,
     postShift,
     getShift,
     queryShiftsRange,
+    deleteShift,
 };

--- a/amplify/backend/function/risestandstrongcb34053a/src/utils/aws-utils.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/utils/aws-utils.js
@@ -107,7 +107,7 @@ async function getShift(startTimestamp) {
 }
 
 /**
- * Funciton that returns all of the shift objects in DynamoDB that have
+ * Function that returns all of the shift objects in DynamoDB that have
  * startTimestamps inbetween startTimestamp and endTimestamp.
  * 
  * @param {Number} startTimestamp 

--- a/src/api.js
+++ b/src/api.js
@@ -23,7 +23,7 @@ export async function getShift(startTimestamp) {
 }
 
 export async function getShiftsRange(startTimestamp, endTimestamp) {
-    return await axios.get(`${BASE_URL}/${SHIFTS}?startTimestamp=${startTimestamp}&&endTimestamp=${endTimestamp}`);
+    return await axios.get(`${BASE_URL}/${SHIFTS}?startTimestamp=${startTimestamp}&endTimestamp=${endTimestamp}`);
 }
 
 export async function deleteShift(startTimestamp) {

--- a/src/api.js
+++ b/src/api.js
@@ -3,17 +3,29 @@ const axios = require('axios');
 
 const BASE_URL = 'https://1nazz9rwh9.execute-api.us-west-2.amazonaws.com/prod';
 
-const ANNOUNCEMENTS = '/announcements';
-const SHIFTS = '/shifts';
+const ANNOUNCEMENTS = 'announcements';
+const SHIFTS = 'shifts';
 
-export async function postAnnouncement(userSub, announcementBody) {
+export async function postAnnouncement(announcementBody) {
     await axios.post(`${BASE_URL}/${ANNOUNCEMENTS}`, { ...announcementBody });
 }
 
-export async function getAnnouncements(userSub) {
+export async function getAnnouncements() {
     await axios.get(`${BASE_URL}/${ANNOUNCEMENTS}`);
 }
 
 export async function postShift(shiftBody) {
     await axios.post(`${BASE_URL}/${SHIFTS}`, { ...shiftBody });
+}
+
+export async function getShift(startTimestamp) {
+    return await axios.get(`${BASE_URL}/${SHIFTS}/${startTimestamp}`);
+}
+
+export async function getShiftsRange(startTimestamp, endTimestamp) {
+    return await axios.get(`${BASE_URL}/${SHIFTS}?startTimestamp=${startTimestamp}&&endTimestamp=${endTimestamp}`);
+}
+
+export async function deleteShift(startTimestamp) {
+    await axios.delete(`${BASE_URL}/${SHIFTS}/${startTimestamp}`);
 }


### PR DESCRIPTION
Implemented Delete shifts endpoint and cleaned up getShifts. Added function in api for getShiftsRange which I forgot to do last week.