### PR TITLE
[RSS-54] DELETE /announcements/:announcementId Endpoint

### DIFF
--- a/amplify/backend/function/risestandstrongcb34053a/src/routes/announcements.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/routes/announcements.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { getAnnouncements } = require('../utils/aws-utils');
 const { postAnnouncement } = require('../utils/aws-utils');
+const { deleteAnnouncement } = require('../utils/aws-utils');
 const router = express.Router();
 
 /**
@@ -150,7 +151,14 @@ router.put('/:announcementId', async (req, res) => {
  *            description: Announcement with the specified announcementId does not exist
  */
 router.delete('/:announcementId', async (req, res) => {
-    res.end();
+    const { announcementId } = req.params;
+    
+    try {
+        await deleteAnnouncement(announcementId);
+        res.end();
+    } catch (err) {
+        res.status(400).json(err);
+    }
 })
 
 module.exports = router;

--- a/amplify/backend/function/risestandstrongcb34053a/src/utils/aws-utils.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/utils/aws-utils.js
@@ -12,9 +12,9 @@ AWS.config.update({region: 'us-west-2'});
 async function postAnnouncement(announcementBody) {
     const docClient = new AWS.DynamoDB.DocumentClient();
     const params = {
-        TableName: 'announcements',
+        TableName: 'announcementsV3',
         Item: {
-            'id': uuidv4(),
+            'announcementId': uuidv4(),
             ...announcementBody
         }
     };
@@ -44,7 +44,7 @@ async function getAnnouncements(){
     };
     const docClient = new AWS.DynamoDB.DocumentClient();
     var params = {
-        TableName : 'announcementsV2',
+        TableName : 'announcementsV3',
     };
 
     try{
@@ -53,6 +53,29 @@ async function getAnnouncements(){
         return data;
     }
     catch (err){
+        console.log(err);
+        throw err;
+    }
+}
+
+/**
+ * DELETE an announcement of the specified announcementId from the announcements
+ * table in DynamoDB. Throws error from DynamoDB if one occurs.
+ *
+ * @param {String} announcementId
+ */
+async function deleteAnnouncement(announcementId){
+    const docClient = new AWS.DynamoDB.DocumentClient();
+    const params = {
+        TableName: 'announcementsV3',
+        Key: {
+            announcementId
+        }
+    };
+
+    try {
+        return await docClient.delete(params).promise();
+    } catch (err) {
         console.log(err);
         throw err;
     }
@@ -100,6 +123,8 @@ async function getShift(startTimestamp) {
         let shift = await docClient.get(params).promise();
         return shift
     } catch (err) {
+    }
+}
 
 async function queryShiftsRange(startTimestamp, endTimestamp) {
     const docClient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10'});
@@ -127,7 +152,8 @@ async function queryShiftsRange(startTimestamp, endTimestamp) {
 
 module.exports = {
     postAnnouncement,
-    getAnnouncements
+    getAnnouncements,
+    deleteAnnouncement,
     postShift,
     getShift,
     queryShiftsRange,

--- a/src/api.js
+++ b/src/api.js
@@ -17,3 +17,7 @@ export async function getAnnouncements(userSub) {
 export async function postShift(shiftBody) {
     await axios.post(`${BASE_URL}/${SHIFTS}`, { ...shiftBody });
 }
+
+export async function deleteAnnouncement(announcementId) {
+    await axios.delete(`${BASE_URL}/${ANNOUNCEMENTS}/${announcementId}`);
+}


### PR DESCRIPTION
Completed DELETE announcements endpoint. Also updated previous announcements endpoints to use new announcementsV3 table. I had to remove the sort key in announcementsV2 because:

1. It wasn't needed
2. I needed it when deleting a record (would've been much more annoying to get the announcementId and createdAt)