### PR TITLE
[RSS-74] Style New Account Page - Desktop

### DIFF
--- a/src/components/NewAccountPage/NewAccountPage.jsx
+++ b/src/components/NewAccountPage/NewAccountPage.jsx
@@ -111,11 +111,6 @@ const StyledHeader = styled(Form.Label)`
       margin-left: auto;
       margin-right: auto;
    }
-   &:hover,
-   &:focus {
-      background-color: transparent;
-      color: #024e6b;
-   }
 `;
 
 const StyledHideButton = styled(Button)`
@@ -126,6 +121,11 @@ const StyledHideButton = styled(Button)`
    font-size: 16px;
    font-family: 'Nunito Sans', sans-serif;
    font-weight: 600;
+   &:hover,
+   &:focus {
+      background-color: transparent;
+      color: #024e6b;
+   }
 `;
 
 const StyledButtonAndEye = styled.div`
@@ -295,16 +295,6 @@ export default () => {
                   </StyledComment>
                </Form.Group>
             </Form.Row>
-            {/* <StyledButtonAndEye>
-               <StyledHideButton onClick={toggleShowPassword}>
-                  {passwordShown ? 'Hide ' : 'Show '}
-                  {passwordShown ? (
-                     <FontAwesomeIcon icon={faEye} />
-                  ) : (
-                     <FontAwesomeIcon icon={faEyeSlash} />
-                  )}
-               </StyledHideButton>
-            </StyledButtonAndEye> */}
             <SubmitButton type="submit">Register</SubmitButton>
          </StyledContainer>
       </Form>

--- a/src/components/NewAccountPage/NewAccountPage.jsx
+++ b/src/components/NewAccountPage/NewAccountPage.jsx
@@ -7,6 +7,19 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import './fonts.css';
 
+const StyledContainer = styled.div`
+   display: flex
+   flex-direction: column;
+   justify-content: space-between;
+   @media only screen and (min-width: 768px) {
+      margin-right: auto;
+      margin-left: auto;
+      width: calc(40vw - 65px);
+      min-width: 400px;
+      max-width: 500px;
+   }
+`;
+
 const SubmitButton = styled(Button)`
    background-color: #024e6b;
    color: white;
@@ -18,8 +31,14 @@ const SubmitButton = styled(Button)`
    display: flex;
    justify-content: flex-end;
    margin-left: auto;
-   margin-top: 50px;
-   margin-right: 35px;
+   margin-top: 26px;
+   margin-right: 20px;
+   margin-bottom: 100px;
+   @media only screen and (min-width: 768px) {
+      margin-right: 0px;
+      margin-left: auto;
+      padding: 8px 30px;
+   }
 `;
 
 const StyledField = styled(Form.Control)`
@@ -29,6 +48,13 @@ const StyledField = styled(Form.Control)`
    font-size: 18px;
    padding: 2px 5px;
    width: calc(100vw - 65px);
+   @media only screen and (min-width: 768px) {
+      margin-left: auto;
+      margin-right: auto;
+      width: calc(40vw - 65px);
+      min-width: 400px;
+      max-width: 500px;
+   }
 `;
 
 const StyledFeedback = styled(Form.Control.Feedback)`
@@ -41,6 +67,11 @@ const StyledLabel = styled(Form.Label)`
    font-size: 18px;
    font-family: 'Nunito Sans', sans-serif;
    font-weight: 700;
+   @media only screen and (min-width: 768px) {
+      width: calc(40vw - 65px);
+      margin-left: auto;
+      margin-right: auto;
+   }
 `;
 
 const StyledSubheader = styled(Form.Label)`
@@ -50,6 +81,10 @@ const StyledSubheader = styled(Form.Label)`
    color: #525252;
    font-family: 'Nunito Sans', sans-serif;
    font-weight: 400;
+   @media only screen and (min-width: 768px) {
+      margin-left: 8px;
+      margin-right: auto;
+   }
 `;
 
 const StyledComment = styled(Form.Label)`
@@ -59,6 +94,11 @@ const StyledComment = styled(Form.Label)`
    color: #525252;
    font-family: 'Nunito Sans', sans-serif;
    font-weight: 400;
+   @media only screen and (min-width: 768px) {
+      width: calc(40vw - 65px);
+      margin-left: auto;
+      margin-right: auto;
+   }
 `;
 
 const StyledHeader = styled(Form.Label)`
@@ -67,6 +107,10 @@ const StyledHeader = styled(Form.Label)`
    font-size: 36px;
    font-family: 'Nunito Sans', sans-serif;
    font-weight: 600;
+   @media only screen and (min-width: 768px) {
+      margin-left: auto;
+      margin-right: auto;
+   }
 `;
 
 const StyledHideButton = styled(Button)`
@@ -84,8 +128,26 @@ const StyledButtonAndEye = styled.div`
    display: flex;
    justify-content: flex-end;
    margin-left: auto;
-   margin-top: -125px;
+   margin-top: -60px;
    margin-right: 20px;
+   @media only screen and (min-width: 768px) {
+      margin-top: -6px;
+      position: absolute;
+      margin-left: auto;
+      margin-right: auto;
+   }
+`;
+
+const StyledSmallContainer = styled.div`
+   @media only screen and (min-width: 768px) {
+      width: calc(40vw - 65px);
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      width: calc(40vw - 65px);
+      min-width: 400px;
+      max-width: 500px;
+   }
 `;
 
 export default () => {
@@ -133,104 +195,118 @@ export default () => {
 
    return (
       <Form noValidate validated={validated} onSubmit={handleSubmit}>
-         <StyledHeader>Register an account</StyledHeader>
-         <Form.Row>
-            <StyledSubheader>All fields are required</StyledSubheader>
-         </Form.Row>
-         <Form.Row>
-            <Form.Group as={Col} md="4" controlId="validationCustom01">
-               <StyledLabel>First name</StyledLabel>
-               <StyledField
-                  required
-                  type="text"
-                  defaultValue={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-               />
-               <StyledFeedback>Looks good!</StyledFeedback>
-               <StyledFeedback type="invalid">
-                  {' '}
-                  Please fill in your first name.{' '}
-               </StyledFeedback>
-            </Form.Group>
-         </Form.Row>
-         <Form.Row>
-            <Form.Group as={Col} md="4" controlId="validationCustom02">
-               <StyledLabel>Last name</StyledLabel>
-               <StyledField
-                  required
-                  type="text"
-                  defaultValue={lastName}
-                  onChange={(e) => setLastName(e.target.value)}
-               />
-               <StyledFeedback>Looks good!</StyledFeedback>
-               <StyledFeedback type="invalid">
-                  {' '}
-                  Please fill in your last name.{' '}
-               </StyledFeedback>
-            </Form.Group>
-         </Form.Row>
-         <Form.Row>
-            <Form.Group as={Col} md="4" controlId="validationCustom03">
-               <StyledLabel>Email</StyledLabel>
-               <StyledField
-                  required
-                  type="text"
-                  defaultValue={email}
-                  onChange={(e) => setEmail(e.target.value)}
-               />
-               <StyledFeedback>Looks good!</StyledFeedback>
-               <StyledFeedback type="invalid">
-                  {' '}
-                  Please fill in your email.{' '}
-               </StyledFeedback>
-            </Form.Group>
-         </Form.Row>
-         <Form.Row>
-            <Form.Group as={Col} md="4" controlId="validationCustom04">
-               <StyledLabel>Phone number</StyledLabel>
-               <StyledField
-                  required
-                  type="text"
-                  defaultValue={phoneNumber}
-                  onChange={(e) => setPhoneNumber(e.target.value)}
-               />
-               <StyledFeedback>Looks good!</StyledFeedback>
-               <StyledFeedback type="invalid">
-                  {' '}
-                  Please fill in your phone number.{' '}
-               </StyledFeedback>
-            </Form.Group>
-         </Form.Row>
-         <Form.Row>
-            <Form.Group as={Col} md="4" controlId="validationCustom05">
-               <StyledLabel>Password</StyledLabel>
-               <StyledField
-                  required
-                  type={passwordShown ? 'text' : 'password'}
-                  defaultValue={password}
-                  onChange={(e) => setPassword(e.target.value)}
-               />
-               <StyledFeedback>Looks good!</StyledFeedback>
-               <StyledFeedback type="invalid">
-                  {' '}
-                  Please fill in your password.{' '}
-               </StyledFeedback>
-               <StyledComment>
-                  * Password must be 6 characters or longer
-               </StyledComment>
-            </Form.Group>
-         </Form.Row>
-         <StyledButtonAndEye>
-            <StyledHideButton onClick={toggleShowPassword}>
-               {passwordShown ? 'Hide ' : 'Show '}
-               {passwordShown ? (
-                  <FontAwesomeIcon icon={faEye} />
-               ) : (
-                  <FontAwesomeIcon icon={faEyeSlash} />
-               )}
-            </StyledHideButton>
-         </StyledButtonAndEye>
-         <SubmitButton type="submit">Register</SubmitButton>
+         <StyledContainer>
+            <StyledHeader>Register an account</StyledHeader>
+            <Form.Row>
+               <StyledSubheader>All fields are required</StyledSubheader>
+            </Form.Row>
+            <Form.Row>
+               <Form.Group as={Col} md="4" controlId="validationCustom01">
+                  <StyledLabel>First name</StyledLabel>
+                  <StyledField
+                     required
+                     type="text"
+                     defaultValue={firstName}
+                     onChange={(e) => setFirstName(e.target.value)}
+                  />
+                  <StyledFeedback>Looks good!</StyledFeedback>
+                  <StyledFeedback type="invalid">
+                     {' '}
+                     Please fill in your first name.{' '}
+                  </StyledFeedback>
+               </Form.Group>
+            </Form.Row>
+            <Form.Row>
+               <Form.Group as={Col} md="4" controlId="validationCustom02">
+                  <StyledLabel>Last name</StyledLabel>
+                  <StyledField
+                     required
+                     type="text"
+                     defaultValue={lastName}
+                     onChange={(e) => setLastName(e.target.value)}
+                  />
+                  <StyledFeedback>Looks good!</StyledFeedback>
+                  <StyledFeedback type="invalid">
+                     {' '}
+                     Please fill in your last name.{' '}
+                  </StyledFeedback>
+               </Form.Group>
+            </Form.Row>
+            <Form.Row>
+               <Form.Group as={Col} md="4" controlId="validationCustom03">
+                  <StyledLabel>Email</StyledLabel>
+                  <StyledField
+                     required
+                     type="text"
+                     defaultValue={email}
+                     onChange={(e) => setEmail(e.target.value)}
+                  />
+                  <StyledFeedback>Looks good!</StyledFeedback>
+                  <StyledFeedback type="invalid">
+                     {' '}
+                     Please fill in your email.{' '}
+                  </StyledFeedback>
+               </Form.Group>
+            </Form.Row>
+            <Form.Row>
+               <Form.Group as={Col} md="4" controlId="validationCustom04">
+                  <StyledLabel>Phone number</StyledLabel>
+                  <StyledField
+                     required
+                     type="text"
+                     defaultValue={phoneNumber}
+                     onChange={(e) => setPhoneNumber(e.target.value)}
+                  />
+                  <StyledFeedback>Looks good!</StyledFeedback>
+                  <StyledFeedback type="invalid">
+                     {' '}
+                     Please fill in your phone number.{' '}
+                  </StyledFeedback>
+               </Form.Group>
+            </Form.Row>
+            <Form.Row>
+               <Form.Group as={Col} md="4" controlId="validationCustom05">
+                  <StyledLabel>Password</StyledLabel>
+                  <StyledSmallContainer>
+                     <StyledField
+                        required
+                        type={passwordShown ? 'text' : 'password'}
+                        defaultValue={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                     />
+                     <StyledButtonAndEye>
+                        <StyledHideButton onClick={toggleShowPassword}>
+                           {passwordShown ? 'Hide ' : 'Show '}
+                           {passwordShown ? (
+                              <FontAwesomeIcon icon={faEye} />
+                           ) : (
+                              <FontAwesomeIcon icon={faEyeSlash} />
+                           )}
+                        </StyledHideButton>
+                     </StyledButtonAndEye>
+                  </StyledSmallContainer>
+                  <StyledFeedback>Looks good!</StyledFeedback>
+                  <StyledFeedback type="invalid">
+                     {' '}
+                     Please fill in your password.{' '}
+                  </StyledFeedback>
+                  <StyledComment>
+                     * Password must be 6 characters or longer
+                  </StyledComment>
+               </Form.Group>
+            </Form.Row>
+            {/* <StyledButtonAndEye>
+               <StyledHideButton onClick={toggleShowPassword}>
+                  {passwordShown ? 'Hide ' : 'Show '}
+                  {passwordShown ? (
+                     <FontAwesomeIcon icon={faEye} />
+                  ) : (
+                     <FontAwesomeIcon icon={faEyeSlash} />
+                  )}
+               </StyledHideButton>
+            </StyledButtonAndEye> */}
+            <SubmitButton type="submit">Register</SubmitButton>
+         </StyledContainer>
       </Form>
    );
 };

--- a/src/components/NewAccountPage/NewAccountPage.jsx
+++ b/src/components/NewAccountPage/NewAccountPage.jsx
@@ -111,6 +111,11 @@ const StyledHeader = styled(Form.Label)`
       margin-left: auto;
       margin-right: auto;
    }
+   &:hover,
+   &:focus {
+      background-color: transparent;
+      color: #024e6b;
+   }
 `;
 
 const StyledHideButton = styled(Button)`
@@ -124,17 +129,12 @@ const StyledHideButton = styled(Button)`
 `;
 
 const StyledButtonAndEye = styled.div`
-   padding: 20px;
-   display: flex;
-   justify-content: flex-end;
-   margin-left: auto;
-   margin-top: -60px;
-   margin-right: 20px;
-   @media only screen and (min-width: 768px) {
-      margin-top: -6px;
+   position: absolute;
+   top: 30px;
+   @media only screen and (max-width: 768px) {
       position: absolute;
-      margin-left: auto;
-      margin-right: auto;
+      top: 30px;
+      right: 40px;
    }
 `;
 


### PR DESCRIPTION
### Version Overview:
- Styled New Account page accordingly to desktop mockups

### Notes:
- `NewAccountPage`: Still need to find a way to get rid of the blue "focused/selection" background when the Show/Hide password button is clicked (I need you to help for this one b/c I can't figure it out)
- `NewAccountPage`: I added a min-width and max-width in addition to dynamic resizing, since I personally felt it looked better. Feel free to request edits if you'd like me to change it.

### Visual:
<img width="2028" alt="Screen Shot 2021-04-19 at 8 22 59 PM" src="https://user-images.githubusercontent.com/42549561/115333245-2e39e800-a14e-11eb-8039-36b738fc57ef.png">
