### PR TITLE
[RSS-57] Implemented Shifts reducers

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,9 @@
 
 // Shift Actions
 export const INITIALIZE_SHIFT = 'INITIALIZE_SHIFT';
+export const ADD_SHIFT = 'ADD_SHIFT';
+export const UPDATE_SHIFT = 'UPDATE_SHIFT';
+export const DELETE_SHIFT = 'DELETE_SHIFT';
 
 // Date Parsing
 export const DAY_OF_WEEK = [

--- a/src/reducers/shiftReducer.js
+++ b/src/reducers/shiftReducer.js
@@ -1,4 +1,9 @@
-import { INITIALIZE_SHIFT } from '../constants';
+import {
+   INITIALIZE_SHIFT,
+   ADD_SHIFT,
+   UPDATE_SHIFT,
+   DELETE_SHIFT,
+} from '../constants';
 
 const initialState = {
    shifts: [],
@@ -7,11 +12,42 @@ const initialState = {
 const shiftReducer = (state = initialState, action) => {
    switch (action.type) {
       case INITIALIZE_SHIFT:
-         console.log('Initializing shift store');
-
          return {
-            shifts: ['initialized'],
+            ...state,
+            shifts: action.shifts,
          };
+      case ADD_SHIFT: {
+         return {
+            ...state,
+            shifts: [...state.shifts, action.newShift],
+         };
+      }
+      case UPDATE_SHIFT: {
+         // TODO: Limit the fields that can be edited from this reducer through
+         // the action creator
+         const { targetShiftTS, newShiftBody } = action;
+
+         const updatedShifts = state.shifts.map((shift) =>
+            shift.startTimestamp === targetShiftTS
+               ? { ...shift, ...newShiftBody }
+               : shift
+         );
+         return {
+            ...state,
+            shifts: updatedShifts,
+         };
+      }
+      case DELETE_SHIFT: {
+         const { targetShiftTS } = action;
+
+         const updatedShifts = state.shifts.filter(
+            (shift) => shift.startTimestamp !== targetShiftTS
+         );
+         return {
+            ...state,
+            shifts: updatedShifts,
+         };
+      }
       default:
          return state;
    }

--- a/src/reducers/shiftReducer.test.js
+++ b/src/reducers/shiftReducer.test.js
@@ -1,5 +1,11 @@
 /* eslint-disable no-undef */
 import shiftReducer from './shiftReducer';
+import {
+   INITIALIZE_SHIFT,
+   ADD_SHIFT,
+   UPDATE_SHIFT,
+   DELETE_SHIFT,
+} from '../constants';
 
 describe('shiftReducer tests', () => {
    it('should have the proper initial state', () => {
@@ -11,6 +17,218 @@ describe('shiftReducer tests', () => {
       // Assert
       expect(initialState).toEqual({
          shifts: [],
+      });
+   });
+
+   describe('INITIALIZE_SHIFT tests', () => {
+      it('Should initialize shifts according to action', () => {
+         // Arrange
+         const testShits = [
+            {
+               startTimestamp: 1614386408390,
+               endTimestamp: 1614386408690,
+               primary: 'Josh Wong',
+            },
+            {
+               startTimestamp: 1614386407390,
+               endTimestamp: 1614386407690,
+               primary: 'Justin Poist',
+            },
+         ];
+
+         // Act
+         const computedState = shiftReducer(undefined, {
+            type: INITIALIZE_SHIFT,
+            shifts: testShits,
+         });
+
+         // Assert
+         expect(computedState.shifts).toEqual(testShits);
+      });
+   });
+
+   describe('ADD_SHIFT tests', () => {
+      it('Should add a new shift to the store', () => {
+         // Arrange
+         const prevState = {
+            shifts: [
+               {
+                  startTimestamp: 1614386408390,
+                  endTimestamp: 1614386408690,
+                  primary: 'Josh Wong',
+               },
+               {
+                  startTimestamp: 1614386407390,
+                  endTimestamp: 1614386407690,
+                  primary: 'Justin Poist',
+               },
+            ],
+         };
+
+         const newShift = {
+            startTimestamp: 1614386401390,
+            endTimestamp: 1614386401690,
+            primary: 'Jack Fales',
+         };
+
+         // Act
+         const computedState = shiftReducer(prevState, {
+            type: ADD_SHIFT,
+            newShift,
+         });
+
+         // Assert
+         expect(computedState.shifts).toEqual([...prevState.shifts, newShift]);
+      });
+   });
+
+   describe('UPDATE_SHIFT tests', () => {
+      it('Should update the shift specified by targetShiftTS', () => {
+         // Arrange
+         const prevState = {
+            shifts: [
+               {
+                  startTimestamp: 1614386408390,
+                  endTimestamp: 1614386408690,
+                  primary: 'Josh Wong',
+               },
+               {
+                  startTimestamp: 1614386407390,
+                  endTimestamp: 1614386407690,
+                  primary: 'Justin Poist',
+               },
+            ],
+         };
+
+         const targetShiftTS = 1614386407390;
+         const newShiftBody = {
+            primary: 'Jack Fales',
+            backup: 'Justin Poist',
+         };
+
+         const expectedShifts = [
+            {
+               startTimestamp: 1614386408390,
+               endTimestamp: 1614386408690,
+               primary: 'Josh Wong',
+            },
+            {
+               startTimestamp: 1614386407390,
+               endTimestamp: 1614386407690,
+               primary: 'Jack Fales',
+               backup: 'Justin Poist',
+            },
+         ];
+
+         // Act
+         const computedState = shiftReducer(prevState, {
+            type: UPDATE_SHIFT,
+            targetShiftTS,
+            newShiftBody,
+         });
+
+         // Assert
+         expect(computedState.shifts).toEqual(expectedShifts);
+      });
+
+      it('Should do nothing if targetShiftTS does not exist', () => {
+         // Arrange
+         const prevState = {
+            shifts: [
+               {
+                  startTimestamp: 1614386408390,
+                  endTimestamp: 1614386408690,
+                  primary: 'Josh Wong',
+               },
+               {
+                  startTimestamp: 1614386407390,
+                  endTimestamp: 1614386407690,
+                  primary: 'Justin Poist',
+               },
+            ],
+         };
+
+         const targetShiftTS = 139;
+
+         // Act
+         const computedState = shiftReducer(prevState, {
+            type: UPDATE_SHIFT,
+            targetShiftTS,
+            newShiftBody: {
+               startTimestamp: 1294580,
+            },
+         });
+
+         // Assert
+         expect(computedState.shifts).toEqual(prevState.shifts);
+      });
+   });
+
+   describe('DELETE_SHIFT tests', () => {
+      it('Should delete the shift specified by targetShiftTS', () => {
+         // Arrange
+         const prevState = {
+            shifts: [
+               {
+                  startTimestamp: 1614386408390,
+                  endTimestamp: 1614386408690,
+                  primary: 'Josh Wong',
+               },
+               {
+                  startTimestamp: 1614386407390,
+                  endTimestamp: 1614386407690,
+                  primary: 'Justin Poist',
+               },
+            ],
+         };
+
+         const targetShiftTS = 1614386407390;
+
+         const expectedShifts = [
+            {
+               startTimestamp: 1614386408390,
+               endTimestamp: 1614386408690,
+               primary: 'Josh Wong',
+            },
+         ];
+
+         // Act
+         const computedState = shiftReducer(prevState, {
+            type: DELETE_SHIFT,
+            targetShiftTS,
+         });
+
+         // Assert
+         expect(computedState.shifts).toEqual(expectedShifts);
+      });
+
+      it('Should do nothing if targetShiftTS does not exist', () => {
+         // Arrange
+         const prevState = {
+            shifts: [
+               {
+                  startTimestamp: 1614386408390,
+                  endTimestamp: 1614386408690,
+                  primary: 'Josh Wong',
+               },
+               {
+                  startTimestamp: 1614386407390,
+                  endTimestamp: 1614386407690,
+                  primary: 'Justin Poist',
+               },
+            ],
+         };
+
+         const targetShiftTS = 139;
+
+         // Act
+         const computedState = shiftReducer(prevState, {
+            type: DELETE_SHIFT,
+            targetShiftTS,
+         });
+
+         // Assert
+         expect(computedState.shifts).toEqual(prevState.shifts);
       });
    });
 });

--- a/src/reducers/shiftReducer.test.js
+++ b/src/reducers/shiftReducer.test.js
@@ -23,7 +23,7 @@ describe('shiftReducer tests', () => {
    describe('INITIALIZE_SHIFT tests', () => {
       it('Should initialize shifts according to action', () => {
          // Arrange
-         const testShits = [
+         const testShifts = [
             {
                startTimestamp: 1614386408390,
                endTimestamp: 1614386408690,
@@ -39,11 +39,11 @@ describe('shiftReducer tests', () => {
          // Act
          const computedState = shiftReducer(undefined, {
             type: INITIALIZE_SHIFT,
-            shifts: testShits,
+            shifts: testShifts,
          });
 
          // Assert
-         expect(computedState.shifts).toEqual(testShits);
+         expect(computedState.shifts).toEqual(testShifts);
       });
    });
 


### PR DESCRIPTION
Implemented shift reducers. I combined all of the update shift requirements into one reducer without restrictions on it. I think the best way to structure this is to have the action creators limit what you can call the reducer with so we don't need to duplicate the code for the reducer and we can continue to use the reducer if we add new fields to shifts. (Based off the mockups and ShiftDetals component I think we should add the phone numbers to the shifts for each of the shift volunteers)