### PR TITLE
Remove unused import

### DIFF
--- a/amplify/backend/function/risestandstrongcb34053a/src/routes/announcements.js
+++ b/amplify/backend/function/risestandstrongcb34053a/src/routes/announcements.js
@@ -6,7 +6,6 @@ const {
    deleteAnnouncement,
 } = require('../utils/aws-utils');
 const router = express.Router();
-const AWS = require('aws-amplify');
 
 /**
  * @swagger


### PR DESCRIPTION
Remove import of aws-amplify from backend that does not use it or have it installed.